### PR TITLE
fix: output images as tensor instead of list

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -5,6 +5,7 @@ from .ldsrlib.LDSR import LDSR
 from folder_paths import get_filename_list, get_full_path
 from comfy.model_management import get_torch_device
 from comfy.utils import ProgressBar
+import torch
 
 
 class LDSRModelLoader:
@@ -73,7 +74,7 @@ class LDSRUpscale:
         for image in images:
             outputs.append(ldsr.superResolution(image, int(steps), pre_downscale, post_downscale, downsample_method))
 
-        return (outputs,)
+        return (torch.stack(outputs),)
 
 
 class LDSRUpscaler:
@@ -122,7 +123,7 @@ class LDSRUpscaler:
         for image in images:
             outputs.append(ldsr.superResolution(image, int(steps), pre_downscale, post_downscale, downsample_method))
 
-        return (outputs, )
+        return (torch.stack(outputs),)
 
 
 NODE_CLASS_MAPPINGS = {


### PR DESCRIPTION
## Context

Piping the output of the LDSR scaler to another node usually returns the error `'list' object has no attribute 'shape'`. This limits what nodes can take an upscaled image as an input.

## The Fix

The error is due to the upscaler returning a list of tensor images instead of a higher dimensional tensor as most nodes expect. It's possible to stack the resulting list into such a higher dimentional tensor, solving the issue if the input images can be assumed to have the same dimensions (but I'm not sure if this is a valid assumption!).

## Testing

Constructed a pipeline that used to fail due to the error and uses both upscaler nodes, then checked that it now succeeds:

| Before | After |
| ------------- | ------------- |
| ![image](https://github.com/flowtyone/ComfyUI-Flowty-LDSR/assets/138787116/1e47b756-ab31-4faa-8153-d972092652fa)  |  ![image](https://github.com/flowtyone/ComfyUI-Flowty-LDSR/assets/138787116/61ec310a-d3ea-47f4-b743-beb4e37ca023) |



